### PR TITLE
공통 Layout 컴포넌트 추가 및 시멘틱 태그 수정

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,3 +1,3 @@
 export default function Footer() {
-  return <div>푸터</div>;
+  return <footer>푸터</footer>;
 }

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,3 +1,3 @@
 export default function Header() {
-  return <div>헤더</div>;
+  return <header>헤더</header>;
 }

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,0 +1,17 @@
+import Header from '@/components/common/Header';
+import Footer from '@/components/common/Footer';
+import { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+export default function Layout({ children }: Props) {
+  return (
+    <div>
+      <Header />
+      <main>{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,14 +1,16 @@
 import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
-import Head from 'next/head';
+import Layout from '@/components/common/Layout';
+import { useRouter } from 'next/router';
 
 export default function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  if (router.pathname === '/_error') return <Component {...pageProps} />;
+
   return (
-    <>
-      <Head>
-        <title>YUMU</title>
-      </Head>
+    <Layout>
       <Component {...pageProps} />
-    </>
+    </Layout>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,13 @@
+import Head from 'next/head';
 import Landing from './landing';
-import Header from '@/components/common/Header';
-import Footer from '@/components/common/Footer';
 
 export default function Home() {
   return (
     <>
-      <Header />
+      <Head>
+        <title>YUMU 유무</title>
+      </Head>
       <Landing />
-      <Footer />
     </>
   );
 }


### PR DESCRIPTION
## 어떤 변경인지

- [x] feat: 기능 변경, 기능 추가
- [ ] fix: 버그 수정
- [ ] design: css만 수정
- [x] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제
- [ ] docs: 문서 작업 (README, pr 템플릿)
- [ ] chore: 기타 작업

## 설명

- Layout 공통 컴포넌트에 header, main(의 children으로 각각의 도메인 페이지), footer가 렌더링 될 수 있도록 구현했습니다.
- 404 페이지에서는 Layout이 적용 되지 않게 예외 사항 구현했습니다.
- header, main, footer 시멘틱 태그로 수정했습니다.


### 이슈 번호

> https://github.com/Team-YUMU/YUMU-FE/issues/[#19]

### To Reviewers

close #19
