### PR TITLE
accessToken/refreshToken 적용

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {
     return config;
   },
   images: {
+    domains: ['yumu-image.s3.ap-northeast-2.amazonaws.com/', 'yu-mu.vercel.app/'],
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -8,16 +8,23 @@ import {
   PutUserProps,
 } from '@/types/types';
 import { authInstance as authAxios, instance as axios } from './axios';
-
 const BASE_URL = `/api/v1`;
 const MY_PAGE_BASE_URL = `${BASE_URL}/mypage`;
 const MY_PAGE_MEMBERS_URL = `${BASE_URL}/member`;
 const AUCTION_BASE_URL = `${BASE_URL}/auction`;
-
+axios.defaults.withCredentials = true;
 // signIn-page API (로그인)
 export async function postAuthLogin(loginData: PostAuthLoginProps) {
   const res = await axios.post<UserInfoWithTokenProps>(`${BASE_URL}/auth/login`, loginData);
-  return res.data;
+  const accessToken = res.headers['authorization'];
+  const refreshToken = res.headers['refresh'];
+  sessionStorage.setItem('accessToken', accessToken);
+  sessionStorage.setItem('refreshToken', refreshToken);
+  try {
+    res.data;
+  } catch (error) {
+    console.log(error);
+  }
 }
 
 // SNS signIn API (SNS 로그인)

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,7 +1,6 @@
 import {
   RegistrationProps,
   UserInfoProps,
-  UserInfoWithTokenProps,
   AuctionCheckProps,
   PostAuthLoginProps,
   PostAuthSignUpProps,
@@ -15,7 +14,7 @@ const AUCTION_BASE_URL = `${BASE_URL}/auction`;
 axios.defaults.withCredentials = true;
 // signIn-page API (로그인)
 export async function postAuthLogin(loginData: PostAuthLoginProps) {
-  const res = await axios.post<UserInfoWithTokenProps>(`${BASE_URL}/auth/login`, loginData);
+  const res = await axios.post(`${BASE_URL}/auth/login`, loginData);
   const accessToken = res.headers['authorization'];
   const refreshToken = res.headers['refresh'];
   sessionStorage.setItem('accessToken', accessToken);

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,22 +1,21 @@
 import axios from 'axios';
-import { Cookies } from 'react-cookie';
-
-const cookies = new Cookies();
-
-const showCookies = (name: string) => {
-  return cookies.get(name);
-};
-
-const refreshToken = showCookies('refreshToken');
+axios.defaults.withCredentials = true;
 
 export const instance = axios.create({
   baseURL: 'http://43.200.219.117:8080/',
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json; charset=UTF-8',
+  },
 });
 
 export const authInstance = axios.create({
   baseURL: 'http://43.200.219.117:8080/',
   headers: {
-    Authorization: refreshToken ? `${refreshToken}` : '',
+    Accept: 'application/json',
+    'Content-Type': 'application/json; charset=UTF-8',
+    Authorization: typeof window !== 'undefined' ? `Bearer ${sessionStorage.getItem('accessToken')}` : '',
+    Refresh: typeof window !== 'undefined' ? `${sessionStorage.getItem('refreshToken')}` : '',
   },
 });
 
@@ -24,7 +23,8 @@ export const authInstance = axios.create({
 export const authInstanceWithMedia = axios.create({
   baseURL: 'http://43.200.219.117:8080/',
   headers: {
-    'Content-Type': 'multipart/form-data',
-    Authorization: refreshToken ? `${refreshToken}` : '',
+    'Content-Type': 'application/json; charset=UTF-8',
+    Authorization: typeof window !== 'undefined' ? `Bearer ${sessionStorage.getItem('accessToken')}` : '',
+    Refresh: typeof window !== 'undefined' ? `${sessionStorage.getItem('refreshToken')}` : '',
   },
 });

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -102,12 +102,6 @@ export interface UserInfoProps {
   profileImage: null | string;
 }
 
-export interface UserInfoWithTokenProps {
-  data: string;
-  refreshToken: string;
-  user: UserInfoProps;
-}
-
 export interface PutUserProps {
   nickname: string;
   introduce: string;


### PR DESCRIPTION
## 어떤 변경인지

- [ ] feat: 기능 변경, 기능 추가
- [ ] fix: 버그 수정
- [ ] design: css만 수정
- [ ] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제
- [ ] docs: 문서 작업 (README, pr 템플릿)
- [X] setting : 폴더 구조 세팅 
- [ ] chore: 기타 작업

## 설명

> pr 내용을 간략히 설명해주세요.

로그인 성공하면 액세스토큰/리프레시토큰을 세션 저장소에 저장을 하고 
세션저장소에 액세스토큰 및 리프레시토큰이 존재하고 헤더의 Authorization/Refersh 밸류 값과 일치한다면 로그인 필요한 
데이터 경로에 접근이 가능 할 겁니다.
임시 로그인으로  테스트  해본 결과 일단 마이페이지 내 정보 조회는 잘 불러와졌습니다.




### 이슈 번호

> 예) https://github.com/Team-YUMU/YUMU-FE/issues/[이슈번호]
> https://github.com/Team-YUMU/YUMU-FE/issues/105

### To Reviewers

close #105 
