### PR TITLE
Pagination 컴포넌트 리팩토링

### DIFF
--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -2,49 +2,53 @@ type PaginationProps = {
   totalPage: number;
   currentPage: number;
   setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
+  startPage: number;
+  endPage: number;
 };
 
-export default function Pagination({ totalPage, currentPage, setCurrentPage }: PaginationProps) {
+export default function Pagination({ totalPage, currentPage, setCurrentPage, startPage, endPage }: PaginationProps) {
   return (
     <div className='flex'>
-      <button
-        type='button'
-        onClick={() => {
-          setCurrentPage((prev) => prev - 1);
-        }}
-        disabled={currentPage === 1}
-        className='cursor p-4 text-14-500 disabled:text-gray-7'
-      >
-        &lt;
-      </button>
+      {currentPage !== 1 && (
+        <button
+          type='button'
+          onClick={() => {
+            setCurrentPage((prev) => prev - 1);
+          }}
+          className='cursor p-4 text-14-500'
+        >
+          &lt;
+        </button>
+      )}
 
       <ol className='flex'>
-        {Array(totalPage)
+        {Array(endPage - startPage + 1)
           .fill(0)
           .map((_, i) => (
-            <li key={i + 1}>
+            <li key={startPage + i}>
               <button
                 type='button'
-                onClick={() => setCurrentPage(i + 1)}
-                aria-current={currentPage === i + 1 ? 'page' : undefined}
+                onClick={() => setCurrentPage(startPage + i)}
+                aria-current={currentPage === startPage + i ? 'page' : undefined}
                 className='p-4 text-14-500 text-gray-7 aria-[current]:text-[#000]'
               >
-                {i + 1}
+                {startPage + i}
               </button>
             </li>
           ))}
       </ol>
 
-      <button
-        type='button'
-        onClick={() => {
-          setCurrentPage((prev) => prev + 1);
-        }}
-        disabled={currentPage === totalPage}
-        className='cursor p-4 text-14-500 disabled:text-gray-7'
-      >
-        &gt;
-      </button>
+      {currentPage !== totalPage && (
+        <button
+          type='button'
+          onClick={() => {
+            setCurrentPage((prev) => prev + 1);
+          }}
+          className='cursor p-4 text-14-500'
+        >
+          &gt;
+        </button>
+      )}
     </div>
   );
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -45,8 +45,13 @@ function SearchPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 12;
   const totalCount = 200;
+  const indexSize = 10;
 
   const totalPage = Math.ceil(totalCount / pageSize);
+  const currentPageGroup = Math.ceil(currentPage / indexSize);
+
+  const startPage = (currentPageGroup - 1) * indexSize + 1;
+  const endPage = Math.min(startPage + indexSize - 1, totalPage);
 
   const {
     data: todos,
@@ -119,7 +124,13 @@ function SearchPage() {
           <EmptyView text={'검색어를 찾을 수 없습니다.'} />
         )}
 
-        <Pagination totalPage={totalPage} currentPage={currentPage} setCurrentPage={setCurrentPage} />
+        <Pagination
+          totalPage={totalPage}
+          currentPage={currentPage}
+          setCurrentPage={setCurrentPage}
+          startPage={startPage}
+          endPage={endPage}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 어떤 변경인지

- [ ] feat: 기능 변경, 기능 추가
- [ ] fix: 버그 수정
- [ ] design: css만 수정
- [x] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제
- [ ] docs: 문서 작업 (README, pr 템플릿)
- [ ] setting : 폴더 구조 세팅 
- [ ] chore: 기타 작업

## 설명

> 현재 모든 page 번호가 화면에 보여지는데, 10개씩 페이지 그룹을 나눠서 화면에서 보이도록 리팩토링 했습니다.
> 1 페이지일 때 "이전" 버튼, 마지막 페이지일 때 "다음" 버튼 사라지도록 리팩토링 했습니다.

### 이슈 번호

> https://github.com/Team-YUMU/YUMU-FE/issues/108

### To Reviewers

close #108
