### PR TITLE
feat: 상세 페이지 API 연동

### DIFF
--- a/src/components/common/LiveTimer.tsx
+++ b/src/components/common/LiveTimer.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react';
+
+/** TODO
+ * 타이머 종료 후에 status: '종료' 업데이트 요청 보내기
+ */
+interface LiveTimerProps {
+  startTime: string;
+  className?: string;
+}
+
+function LiveTimer({ startTime, className }: LiveTimerProps) {
+  const [remainingTime, setRemainingTime] = useState(0);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      const currentTime = new Date().getTime();
+      const targetTime = new Date(startTime).getTime() + 3600000;
+      const timeDifference = targetTime - currentTime;
+
+      if (timeDifference > 0) {
+        setRemainingTime(timeDifference);
+      } else {
+        clearInterval(intervalId);
+      }
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, [startTime]);
+
+  const formatTime = (time: number) => {
+    const hours = Math.floor(time / 3600000);
+    const minutes = Math.floor((time % 3600000) / 60000);
+    const seconds = Math.floor((time % 60000) / 1000);
+    return `${String(hours).padStart(2, '0')} : ${String(minutes).padStart(2, '0')} : ${String(seconds).padStart(2, '0')}`;
+  };
+
+  return <strong className={`text-16-700 text-red-F ${className}`}>{formatTime(remainingTime)}</strong>;
+}
+
+export default LiveTimer;

--- a/src/mocks/auctionDetail.json
+++ b/src/mocks/auctionDetail.json
@@ -1,0 +1,26 @@
+[
+  {
+    "artInfo": {
+      "id": 1,
+      "artName": "Draw your own map (Langley, BC)",
+      "artImage": "https://ymkimstorage.s3.ap-northeast-2.amazonaws.com/art4.png",
+      "artist": "에디강 Eddie Kang",
+      "status": "진행중",
+      "createdAt": "2024-03-24T09:07:40.478Z",
+      "wishCnt": 10
+    },
+    "id": 0,
+    "artDescription": "에디강 작가에게 예술은 행복을 전달하는 매개체이다. 작가는 상상 속 캐릭터들이 등장하는 해피 플레이스(Happy Place)를 그려냄으로써, 지친 현대인들을 위로해 준다. 포근한 털의 질감과 실루엣을 제외하고 형태를 알 수 없는 ‘Yeti’는 마음으로만 볼 수 있는 행복한 에너지를 전달해 주며, 현실에 어떤 일이 일어나도 괜찮을 거라는 위안을 건네줄 것이다.",
+    "artSize": "30x30",
+    "artCreatedDate": "2024-03-24T09:07:40.478Z",
+    "auctionStartDate": "2024-03-24T09:07:40.478Z",
+    "auctionEndDate": "2024-03-24T10:07:40.478Z",
+    "defaultBid": 300000,
+    "winningBid": 900000,
+    "winningBidder": "별튤립",
+    "notice": "* Edition 100, 한정으로 제작된 작품입니다. * 해당 상품은 액자가 포함된 아트 포스터로 블랙 알루미늄 프레임으로 표구 되어 배송 됩니다. (제작 기간 2-3주 소요)",
+    "receiveType": "EMAIL"
+  }
+]
+
+

--- a/src/pages/auction/[auctionid]/detail/index.tsx
+++ b/src/pages/auction/[auctionid]/detail/index.tsx
@@ -1,96 +1,147 @@
-import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { AuctionDetail } from '@/components/common/AuctionDetail';
 import { ExhibitionCarousel } from '@/components/common/ExhibitionCarousel';
-import { Separator } from '@/components/ui/separator';
 import InfoBox from '@/components/common/InfoBox';
 import LikeButton from '@/components/common/LikeButton';
+import LiveTimer from '@/components/common/LiveTimer';
+import ScrollButtons from '@/components/common/ScrollButtons';
+import { Separator } from '@/components/ui/separator';
 import { BestAuction } from '@/components/common/BestAuction';
-import testArts from '@/mocks/testArts.json';
+import { useRouter } from 'next/router';
+import { useQuery } from '@tanstack/react-query';
+import { getAuctionDetails } from '@/services/api';
+
+/** TODO
+ * 서버사이드 렌더링으로 리팩토링
+ * NaN 초기값 이슈 해결 하기
+ * 찜 하기 구현하기
+ */
 
 export default function AuctionDetailPage() {
-  const artData = testArts.results;
-  const [arts, setArts] = useState(artData);
+  const router = useRouter();
+  const { auctionid } = router.query;
+
+  const { data: auctionDetailsData = [] } = useQuery({
+    queryKey: ['auctionDetail'],
+    queryFn: () => getAuctionDetails(Number(auctionid)),
+    initialData: [],
+  });
+
+  const { artName, artSubTitle, artImage, artist, status } = auctionDetailsData?.artInfo ?? [];
+  const { artDescription, auctionStartDate, auctionEndDate } = auctionDetailsData;
+
+  const formatDate = (dateString: string, type: string) => {
+    const dateObject = new Date(dateString);
+
+    const year = dateObject.getFullYear();
+    const month = String(dateObject.getMonth() + 1).padStart(2, '0');
+    const date = String(dateObject.getDate()).padStart(2, '0');
+    const hours = String(dateObject.getHours()).padStart(2, '0');
+    const minutes = String(dateObject.getMinutes()).padStart(2, '0');
+
+    if (type === 'YYYY년 MM월 DD일 HH:MM') {
+      return `${year}년 ${month}월 ${date}일 ${hours}:${minutes}`;
+    } else if (type === 'MM.DD') {
+      return `${month}.${date} ${hours}:${minutes}`;
+    }
+  };
+
+  let linkText = '';
+
+  switch (status) {
+    case 'ON':
+      linkText = `${formatDate(auctionStartDate, 'MM.DD')} 오픈 예정`;
+      break;
+    case 'NOW':
+      linkText = 'Live 경매 참가하기';
+      break;
+    case 'DONE':
+      linkText = '종료';
+      break;
+    default:
+      linkText = `${formatDate(auctionStartDate, 'MM.DD')} 오픈 예정`;
+  }
 
   return (
-    <div className='mx-auto my-0 flex w-[136.8rem] flex-col gap-20'>
-      <h2 className='font-TheJamsil text-36-400 text-black-2'>문은주 Moon Eunjoo 이불 밖은 위험해 2, 2023</h2>
-      <div className='flex gap-5'>
-        <section>
-          <div className='relative mb-[1.8rem] h-[54rem] w-[91rem] overflow-hidden rounded-[1rem] bg-gray-100'>
-            <Image src='https://ymkimstorage.s3.ap-northeast-2.amazonaws.com/art2.png' alt='작품 이미지' fill />
+    <div className='relative mx-auto my-0 flex w-[136.8rem] flex-col pb-[10.5rem]'>
+      <h2 className='mb-[4rem] font-[TheJamsil] text-36-400 text-black-2'>{artName}</h2>
+
+      <div className='mb-[8rem] flex gap-[2rem]'>
+        <section className='w-[91rem]'>
+          <div className='relative mb-[1.8rem] h-[54rem] overflow-hidden rounded-[1rem] bg-gray-100'>
+            <Image src={artImage} alt={artName} fill />
           </div>
 
           <InfoBox className='mb-[3rem]' />
 
-          <AuctionDetail />
+          <AuctionDetail {...auctionDetailsData} />
         </section>
 
-        <section>
-          <div className='w-[45.8rem] rounded-[1rem] border px-[3.7rem] pb-[3.4rem] pt-[4.1rem]'>
-            <div className='mb-10'>
-              <div className='flex items-center justify-between'>
-                <div className='mb-3 flex gap-4 text-gray-99'>
-                  <span className='text-16-600'>아티스트</span>
-                  <span className='block text-16-500'>문은주 Moon Eunjoo</span>
+        <section className='flex-1'>
+          <div className='flex h-[63.8rem] flex-col rounded-[1rem] border px-[3.7rem] pb-[3.4rem] pt-[4.1rem]'>
+            <div className='mb-[1.2rem] flex items-center justify-between'>
+              <div className='flex gap-4 text-gray-99'>
+                <span className='text-16-600'>아티스트</span>
+                <span className='block text-16-500'>{artist}</span>
+              </div>
+
+              <LikeButton />
+            </div>
+
+            <div className='mb-[3rem] flex-1'>
+              <h2 className='mb-[1.6rem] font-[TheJamsil] text-36-400 text-black-2'>{artSubTitle}</h2>
+              <p className='text-18-500 text-gray-99'>{artDescription}</p>
+            </div>
+
+            <div>
+              <div className='flex flex-col'>
+                <span className='text-16-500 text-gray-99'>라이브 오픈까지 남은 시간</span>
+                <span className='text-18-500 text-[#dcdcdc]'>라이브 {status}</span>
+              </div>
+
+              <Separator className='my-[2rem]' />
+
+              <div className='flex flex-col gap-[0.6rem] '>
+                <div className='flex min-w-[6.3rem] gap-12 text-gray-99'>
+                  <span className='text-16-700'>경매 시작</span>
+                  <span className='text-16-500'>{formatDate(auctionStartDate, 'YYYY년 MM월 DD일 HH:MM')}</span>
                 </div>
 
-                <LikeButton />
+                <div className='flex min-w-[6.3rem] gap-12 text-gray-99'>
+                  <span className='text-16-700'>경매 마감</span>
+                  <span className='text-16-500'>{formatDate(auctionEndDate, 'YYYY년 MM월 DD일 HH:MM')}</span>
+                </div>
               </div>
 
-              <h2 className='mb-4 font-TheJamsil text-36-400 text-black-2'>이불 밖은 위험해 2, 2023</h2>
-              <p className='min-h-[19.3rem] text-18-500 text-gray-99'>
-                대중과 작가가 만날 수 있는 특별한 교류의 장, 프린트베이커리 문화기획 프로젝트 오픈 스튜디오가 10월 21일
-                (토) 에 오픈합니다. 가나아뜰리에 입주 작가와 PBG 전속작가, 그리고 평범한 마법봉이 협업하여 기부 전시를
-                진행하며 판매 수익금의 일부는 발달장애 예술 교육을 위해 기부됩니다. 온라인에서 전시될 작품의 일부를 먼저
-                만나보세요!
-              </p>
-            </div>
+              <div className='relative'>
+                {status === 'NOW' && (
+                  <div className='absolute left-[50%] top-[-50%] flex h-[3.5rem] w-[21.2rem] translate-x-[-50%] translate-y-[40%] items-center justify-center gap-[1.8rem] rounded-full border-4 border-red-F bg-white text-red-F'>
+                    <span className='text-16-900'>LIVING</span>
+                    <LiveTimer startTime={auctionStartDate} />
+                  </div>
+                )}
 
-            <div className='flex flex-col'>
-              <span className='text-16-500 text-gray-99'>라이브 오픈까지 남은 시간</span>
-              <span className='text-18-500 text-[#dcdcdc]'>라이브 진행 중</span>
-            </div>
-
-            <Separator className='my-5' />
-
-            <div className='mb-[3rem] flex flex-col gap-[0.6rem] '>
-              <div className='flex min-w-[6.3rem] gap-12 text-gray-99'>
-                <span className='text-16-700'>경매 시작</span>
-                <span className='text-16-500'>2024년 03월 18일 08:00</span>
+                <Link
+                  href={`/auction/${auctionid}/live`}
+                  className={`mt-[4.8rem] flex h-[6.4rem] w-full items-center justify-center rounded-[0.6rem] ${status === 'NOW' ? 'mt-[3rem] bg-red-F' : 'pointer-events-none bg-[#B3B3B3]'} font-TheJamsil text-[2.6rem] font-bold text-white`}
+                >
+                  {linkText}
+                </Link>
               </div>
-
-              <div className='flex min-w-[6.3rem] gap-12 text-gray-99'>
-                <span className='text-16-700'>경매 마감</span>
-                <span className='text-16-500'>2024년 03월 18일 23:00</span>
-              </div>
-            </div>
-
-            <div className='relative'>
-              <div className='absolute left-[50%] top-[-50%] flex h-[3.5rem] w-[21.2rem] translate-x-[-50%] translate-y-[45%] items-center justify-center gap-[1.8rem] rounded-full border-4 border-[#FF7752] border-[text-red-F] bg-white text-red-F'>
-                <span className='text-16-900'>LIVE</span>
-                <strong className='text-16-700'>00 : 30 : 59</strong>
-              </div>
-
-              <Link
-                href={``}
-                className='flex h-[6.4rem] w-full items-center justify-center rounded-[0.6rem] bg-red-F font-TheJamsil text-[2.6rem] font-bold text-white'
-              >
-                Live 경매 참가하기
-              </Link>
             </div>
           </div>
         </section>
       </div>
 
-      <BestAuction />
+      <BestAuction className='mb-[8rem]' />
 
       <section>
         <h2 className='sr-only'>기획전</h2>
-
         <ExhibitionCarousel />
       </section>
+
+      <ScrollButtons />
     </div>
   );
 }


### PR DESCRIPTION
## 어떤 변경인지

- [x] feat: 기능 변경, 기능 추가
- [ ] fix: 버그 수정
- [ ] design: css만 수정
- [x] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제
- [ ] docs: 문서 작업 (README, pr 템플릿)
- [ ] setting : 폴더 구조 세팅 
- [ ] chore: 기타 작업

## 설명

> 경매 상세 페이지 API 연동 했습니다.
> LiveTimer 기능 구현 했습니다. 
> 라이브 status 에 따라 버튼 디자인과 기능 동적으로 바뀌도록 구현했습니다.

예시)  타이머 테스트시에 auctionStartDate에 '현재 시간 string'을 넣어주면 됩니다.
```
<LiveTimer startTime={auctionStartDate} /> 
```
https://github.com/Team-YUMU/YUMU-FE/assets/97681668/34cbf983-11b7-4682-aadf-8ad228b352b6

<img width="1680" alt="스크린샷 2024-04-02 오전 10 56 43" src="https://github.com/Team-YUMU/YUMU-FE/assets/97681668/901e05a4-f8e3-4b0d-8692-d505595572e6">

<img width="1680" alt="스크린샷 2024-04-02 오전 10 57 26" src="https://github.com/Team-YUMU/YUMU-FE/assets/97681668/119ecb0c-1bba-4e15-9795-8313b200de22">

### 이슈 번호

> https://github.com/Team-YUMU/YUMU-FE/issues/118

### To Reviewers

close #118
