### PR TITLE
Signup 페이지 이메일, 닉네임 중복체크 검사

### DIFF
--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -33,52 +33,84 @@ export default function SignUpPage() {
   const {
     register,
     handleSubmit,
+    getValues,
     formState: { errors },
   } = useForm<FormData>({ resolver: zodResolver(schemaSignup) });
 
   const onSubmit = async (data: FormData) => {
     try {
-      const emailCheck = await getEmailCheck(data.email);
-      console.log(emailCheck);
       setIsModalOpen(true);
       await postMember(data);
     } catch (error) {
       console.log('onSubmit error', error);
-      if (error instanceof AxiosError) {
-        // const nicknameErrorMessage: string = error.response?.data.errorMessage;
-        const emailErrorMessage: string = error.response?.data.errorMessage;
-        setErrorMessage(emailErrorMessage);
-        // setErrorMessage(nicknameErrorMessage);
-      }
     }
   };
+
   const [errorMessage, setErrorMessage] = useState('');
-  //  const [errorMessage, setNicknameErrorMessage] = useState('');
-  /*
-  const handleCheckNickname = async (data: FormData) => {
-    console.log('clicked');
+
+  // const handleCheckNickname = async () => {
+  //   const nicknameParams = getValues('nickname');
+  //   try {
+  //     const nicknameCheck = await getNicknameCheck(nicknameParams);
+  //     console.log(nicknameCheck);
+  //   } catch (error) {
+  //     if (error instanceof AxiosError) {
+  //       const nicknameErrorMessage: string = error.response?.data.errorMessage;
+  //       setErrorMessage(nicknameErrorMessage);
+  //     }
+  //   }
+  // };
+  // const onChangeNickName = async () => {
+  //   const nicknameParams = getValues('nickname');
+  //   try {
+  //     await putMemberNickNameData(nicknameParams);
+  //     alert('성공적으로 수정되었습니다.');
+  //   } catch (error) {
+  //     if (error instanceof AxiosError) {
+  //       alert(error.response?.data.errorMessage);
+  //     }
+  //   }
+  // };
+  const handleCheckDuplicate = async (key: keyof FormData) => {
+    const value = getValues(key);
+
     try {
-      const nicknameCheck = await getNicknameCheck(data.nickname);
-      console.log(nicknameCheck);
+      if (key === 'nickname') {
+        try {
+          const nicknameCheck = await getNicknameCheck(value);
+        } catch (error) {}
+      } else if (key === 'email') {
+        const emailCheck = await getEmailCheck(value);
+        console.log(emailCheck);
+      }
     } catch (error) {
       if (error instanceof AxiosError) {
-        const nicknameErrorMessage: string = error.response?.data.errorMessage;
-        setEmailErrorMessage(nicknameErrorMessage);
+        const errorMessage: string = error.response?.data.errorMessage;
+        setErrorMessage(errorMessage);
+      }
+
+      if (key === 'nickname') {
+        setErrorMessage('nickname');
+      } else if (key === 'email') {
+        setErrorMessage('email');
       }
     }
   };
-  const handleCheckEmail = async (data: FormData) => {
-    try {
-      const emailCheck = await getEmailCheck(data.email);
-      console.log(emailCheck);
-    } catch (error) {
-      if (error instanceof AxiosError) {
-        const emailErrorMessage: string = error.response?.data.errorMessage;
-        setErrorMessage(emailErrorMessage);
-      }
-    }
-  };
-*/
+  // const handleCheckEmail = async () => {
+  //   const emailParams = getValues('email');
+  //   try {
+  //     await getEmailCheck(emailParams);
+  //   } catch (error) {
+  //     if (error instanceof AxiosError) {
+  //       // const nicknameErrorMessage: string = error.response?.data.errorMessage;
+  //       const emailErrorMessage: string = error.response?.data.errorMessage;
+  //       setErrorMessage(emailErrorMessage);
+  //       console.log(error.response?.data);
+  //       // setErrorMessage(nicknameErrorMessage);
+  //     }
+  //   }
+  // };
+
   return (
     <div className='flex min-h-screen flex-col items-center justify-center'>
       <AlertDialog>
@@ -103,7 +135,9 @@ export default function SignUpPage() {
                 {...register('nickname')}
               />
 
-              <Button className='absolute bottom-6 right-6'>중복확인</Button>
+              <Button type='button' onClick={() => handleCheckDuplicate()} className='absolute bottom-6 right-6'>
+                중복확인
+              </Button>
             </div>
             <div className='relative flex items-center justify-end'>
               <AuthInput
@@ -114,7 +148,9 @@ export default function SignUpPage() {
                 className={`h-[6.4rem] w-[43.8rem] `}
                 {...register('email')}
               />
-              <Button className='absolute bottom-6 right-6'>중복확인</Button>
+              <Button type='button' onClick={() => handleCheckDuplicate()} className='absolute bottom-6 right-6'>
+                중복확인
+              </Button>
             </div>
             <AuthInput
               type='password'


### PR DESCRIPTION
## 어떤 변경인지

- [x] feat: 기능 변경, 기능 추가
- [ ] fix: 버그 수정
- [ ] design: css만 수정
- [ ] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제
- [ ] docs: 문서 작업 (README, pr 템플릿)
- [ ] setting : 폴더 구조 세팅 
- [x] chore: 기타 작업

## 설명

> pr 내용을 간략히 설명해주세요.
중복검사 기능은 완료했으나  두가지 문제가 있습니다. 
1. 아래와 같이 zod 검사가 겹쳐지는 문제
<img width="538" alt="Screenshot 2024-04-02 at 4 34 37 PM" src="https://github.com/Team-YUMU/YUMU-FE/assets/116065415/e9737fdf-850a-481b-8374-6791a73f3a49">
2. 중복검사를 모두 마치고 onSubmit 하도록 하는 로직 구현 문제

다른 브랜치에서 이부분 수정하겠습니다.

### 이슈 번호

> 예) https://github.com/Team-YUMU/YUMU-FE/issues/[이슈번호]
> https://github.com/Team-YUMU/YUMU-FE/issues/175

### To Reviewers

close #175 
