### PR TITLE
회원가입 인풋 에러메시지 겹치는 문제 해결

### DIFF
--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -33,6 +33,7 @@ export default function SignUpPage() {
     register,
     handleSubmit,
     getValues,
+    setError,
     formState: { errors },
   } = useForm<FormData>({ resolver: zodResolver(schemaSignup), reValidateMode: 'onBlur' });
 
@@ -42,6 +43,8 @@ export default function SignUpPage() {
   const [emailError, setEmailError] = useState('');
 
   const handleCheckDuplicate = async (key: keyof FormData) => {
+    setError('nickname', {});
+    setError('email', {});
     const value = getValues(key);
     try {
       let emailresult;
@@ -49,12 +52,8 @@ export default function SignUpPage() {
 
       if (key === 'nickname') {
         nicknameresult = await getNicknameCheck(value);
-        setNicknameCheck('');
-        setnickNameError('');
       } else if (key === 'email') {
         emailresult = await getEmailCheck(value);
-        setEmailCheck('');
-        setEmailError('');
       }
 
       if (nicknameresult) {
@@ -84,8 +83,7 @@ export default function SignUpPage() {
       }
     }
   };
-  const [isNicknameChecked, setIsNicknameChecked] = useState(false);
-  const [isEmailChecked, setIsEmailChecked] = useState(false);
+
   const [signupMsg, setSignupMsg] = useState('');
 
   const onSubmit = async (data: FormData) => {
@@ -120,6 +118,13 @@ export default function SignUpPage() {
       }
     }
   };
+  const handleReset = () => {
+    setEmailError('');
+    setEmailCheck('');
+    setnickNameError('');
+    setNicknameCheck('');
+  };
+
   return (
     <div className='flex min-h-[80vh] flex-col items-center justify-center'>
       <AlertDialog>
@@ -131,7 +136,7 @@ export default function SignUpPage() {
 
           <form
             noValidate
-            className={` relative flex w-full flex-col items-center justify-center ${errors.email ? 'gap-[3rem]' : 'gap-[3rem]'}`}
+            className={` relative flex w-full flex-col items-center justify-center ${errors.nickname || errors.email ? 'gap-[3rem]' : 'gap-[2rem]'}`}
             onSubmit={handleSubmit(onSubmit)}
           >
             <div className='h-[6.4rem] w-[43.8rem]'>
@@ -160,7 +165,7 @@ export default function SignUpPage() {
               )}
             </div>
 
-            <div>
+            <div className='h-[6.4rem] w-[43.8rem]'>
               <div className='relative flex items-center justify-end'>
                 <AuthInput
                   type='email'
@@ -201,7 +206,13 @@ export default function SignUpPage() {
               className=' h-[6.4rem] w-[43.8rem]'
             />
             <AlertDialogTrigger asChild>
-              <Button variant='default' className=' mt-7 bg-red-F text-[2rem]' type='submit' size='auth'>
+              <Button
+                onClick={() => handleReset()}
+                variant='default'
+                className=' mt-7 bg-red-F text-[2rem]'
+                type='submit'
+                size='auth'
+              >
                 회원가입
               </Button>
             </AlertDialogTrigger>


### PR DESCRIPTION
## 어떤 변경인지

- [ ] feat: 기능 변경, 기능 추가
- [x] fix: 버그 수정
- [ ] design: css만 수정
- [ ] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제
- [ ] docs: 문서 작업 (README, pr 템플릿)
- [ ] setting : 폴더 구조 세팅 
- [x] chore: 기타 작업

## 설명

> pr 내용을 간략히 설명해주세요.
회원가입 인풋 에러메시지 겹치는 문제 해결했습니다. 
[회원가입 로직에 따른 모달띄우기 수정했습니다.

### 이슈 번호

> 예) https://github.com/Team-YUMU/YUMU-FE/issues/[이슈번호]
> https://github.com/Team-YUMU/YUMU-FE/issues/221

### To Reviewers

close #221
