### PR TITLE
refactor : Header/Mypage useQuery,infiniteQuery  staleTime 설정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -26,6 +26,7 @@ export default function Header() {
   const { data: memberData } = useQuery<userData>({
     queryKey: ['memberData'],
     queryFn: () => getMemberInfo(),
+    staleTime: 1000 * 60 * 5,
   });
 
   const handleLogout = async () => {

--- a/src/components/domain/myPage/Tabs/BuyHistory.tsx
+++ b/src/components/domain/myPage/Tabs/BuyHistory.tsx
@@ -29,6 +29,7 @@ export default function BuyHistory() {
     queryFn: ({ pageParam = 999999 }) => getBuyHistory(pageParam, 6),
     initialPageParam: 999999,
     retry: 0,
+    staleTime: 1000 * 60 * 5,
     getNextPageParam: (lastPage) => (!lastPage?.isLast ? lastPage?.nextLastPostId : undefined),
   });
 

--- a/src/components/domain/myPage/Tabs/Edit/Edit.tsx
+++ b/src/components/domain/myPage/Tabs/Edit/Edit.tsx
@@ -26,6 +26,7 @@ export default function Edit() {
   const { data: memberInfo } = useQuery<FormData>({
     queryKey: ['memberData'],
     queryFn: () => getMemberInfo(),
+    staleTime: 1000 * 60 * 5,
   });
 
   const queryClient = useQueryClient();

--- a/src/components/domain/myPage/Tabs/SalesHistory.tsx
+++ b/src/components/domain/myPage/Tabs/SalesHistory.tsx
@@ -32,6 +32,7 @@ export default function SalesHistory() {
     queryFn: ({ pageParam = 999999 }) => getSalesHistory(pageParam, 5),
     initialPageParam: 999999,
     retry: 0,
+    staleTime: 1000 * 60 * 5,
     getNextPageParam: (lastPage) => (!lastPage?.isLast ? lastPage?.nextLastPostId : undefined),
   });
 

--- a/src/components/domain/myPage/Tabs/WishList.tsx
+++ b/src/components/domain/myPage/Tabs/WishList.tsx
@@ -26,6 +26,7 @@ export default function WishList() {
     queryFn: ({ pageParam = 999999 }) => getWishHistory(pageParam, 6),
     initialPageParam: 999999,
     retry: 0,
+    staleTime: 1000 * 60 * 5,
     getNextPageParam: (lastPage) => (!lastPage?.isLast ? lastPage?.nextLastPostId : undefined),
   });
 


### PR DESCRIPTION
## 어떤 변경인지

- [ ] feat: 기능 변경, 기능 추가
- [ ] fix: 버그 수정
- [ ] design: css만 수정
- [X] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제
- [ ] docs: 문서 작업 (README, pr 템플릿)
- [ ] setting : 폴더 구조 세팅 
- [ ] chore: 기타 작업

## 설명

> pr 내용을 간략히 설명해주세요.

Header/myPage 컴포넌트에서 useQuery, infiniteQuery 로 캐싱 한 데이터들은 기본적으로  stale으로 간주하기 때문에 staleTime 속성을 활용하여
데이터를 계속해서 새로 받아오지 않게 설정했습니다. 

### 이슈 번호

> 예) https://github.com/Team-YUMU/YUMU-FE/issues/[이슈번호]
> https://github.com/Team-YUMU/YUMU-FE/issues/276

### To Reviewers

close #276
